### PR TITLE
README added

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@ data-structures consisting of `Hash` and `Array` elements.
 
 ## Example Usage
 
-    describe "deep matchers usage" do
-      it "should compare data-structures recursively" do
-        expected = {:key => ["values", "are", ["good"]]}
+```ruby
+describe "deep matchers usage" do
+  it "should compare data-structures recursively" do
+    expected = {:key => ["values", "are", ["good"]]}
 
-        get :get_expected_json
+    get :get_expected_json
 
-        body = JSON.parse(response.body)
-        body.should deep_eql expected
-      end
-    end
+    body = JSON.parse(response.body)
+    body.should deep_eql expected
+  end
+end
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# RSpec Deep Matchers
+
+This gem adds a custom matcher to RSpec to recursively compare nested Ruby
+data-structures consisting of `Hash` and `Array` elements.
+
+## Example Usage
+
+    describe "deep matchers usage" do
+      it "should compare data-structures recursively" do
+        expected = {:key => ["values", "are", ["good"]]}
+
+        get :get_expected_json
+
+        body = JSON.parse(response.body)
+        body.should deep_eql expected
+      end
+    end

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ describe "deep matchers usage" do
   it "should compare data-structures recursively" do
     expected = {:key => ["values", "are", ["good"]]}
 
-    get :get_expected_json
+    get :get_expected_json, :format => js
 
     body = JSON.parse(response.body)
     body.should deep_eql expected


### PR DESCRIPTION
Hello Vitaliy,

Firstly, thanks for the very handy rspec-deep-matchers gem.  It is extremely helpful and simple to use.  Since there was no README included I had to figure out exactly how to use the gem.  To save anyone else interested in using the gem that same work I've written a quick and simple README in github-markdown format so it is "pretty" when viewed in GitHub.

Thank you,
Dave
