### PR TITLE
Add awesome_print if available.

### DIFF
--- a/lib/deep/matchers/deep_eql.rb
+++ b/lib/deep/matchers/deep_eql.rb
@@ -8,6 +8,13 @@ module Deep
     class DeepEql
 
       def initialize(expectation)
+        begin
+          require 'awesome_print'
+          require 'awesome_print/core_ext/kernel'
+          @have_ap = true
+        rescue Exception => e
+          @have_ap = false
+        end
         @expectation = expectation
       end
 
@@ -32,14 +39,23 @@ module Deep
         result
       end
 
+      def pretty_print(thing)
+        if @have_ap
+          thing.awesome_inspect(:plain => true)
+        else
+          thing.inspect
+        end
+      end
+
       def failure_message_for_should
-        "expected #{@target.inspect} to be deep_eql with #{@expectation.inspect}"
+        "expected #{pretty_print @target} to be deep_eql with #{pretty_print @expectation}"
       end
 
       def failure_message_for_should_not
-        "expected #{@target.inspect} not to be in deep_eql with #{@expectation.inspect}"
+        "expected #{pretty_print @target} not to be in deep_eql with #{pretty_print @expectation}"
       end
     end
 
   end
 end
+

--- a/rspec-deep-matchers.gemspec
+++ b/rspec-deep-matchers.gemspec
@@ -23,4 +23,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency('guard-rspec')
   s.add_development_dependency('growl')
+  s.add_development_dependency('awesome_print')
 end

--- a/spec/lib/rspec/matchers/deep_eql_spec.rb
+++ b/spec/lib/rspec/matchers/deep_eql_spec.rb
@@ -134,4 +134,22 @@ describe 'deep_eql' do
 
   end
 
+  context "pretty printing" do
+      actual = { :foo => "bar", :baz => "quux", :foo2 => "bar", :baz2 => "quux", :foo3 => "bar", :baz3 => "quux",}
+      exp    = { :foo => "bar", :baz => "fnar" }
+      de = Deep::Matchers::DeepEql.new(exp)
+      de.matches?(actual).should == false
+      de.failure_message_for_should.should == 'expected {
+     :foo => "bar",
+     :baz => "quux",
+    :foo2 => "bar",
+    :baz2 => "quux",
+    :foo3 => "bar",
+    :baz3 => "quux"
+} to be deep_eql with {
+    :foo => "bar",
+    :baz => "fnar"
+}'
+    end
 end
+


### PR DESCRIPTION
This makes working out what the differences between complex structures is
much easier as they're pretty printed across multiple lines.
